### PR TITLE
Hotfix/interface name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(UNAME), Darwin)
 	PUBLISH_SSH_PORT = -p $(SSH_PORT):22
 	RESOLVCONF := /etc/resolv.conf
 else
-	LOOPBACK := $(shell ifconfig | grep -i LOOPBACK  | head -n1 | cut -d\   -f1 | sed -e 's#:##')
+	LOOPBACK := $(shell ifconfig | grep -i LOOPBACK  | head -n1 | cut -d\  -f1 | sed -e 's\#:\#\#')
 	IP := $(shell ifconfig docker0 | grep "inet " | cut -dt -f2 | cut -d: -f2 | sed -e 's\# \#\#' | cut -d\  -f1)
 	DOCKER_CONF_FOLDER := /etc/docker
 	DNSs := $(shell nmcli dev show | grep DNS|  cut -d\: -f2 | sort | uniq | sed s/\ //g | sed ':a;N;$!ba;s/\\\n/","/g');

--- a/conf/dnsmasq.local
+++ b/conf/dnsmasq.local
@@ -1,6 +1,6 @@
 strict-order
 bind-interfaces
-interface=lo0
+interface=${LOOPBACK}
 interface=docker0
 
 server=/${TLD}/${IP}


### PR DESCRIPTION
In Ubuntu 16.04, the loopback interface name is called `lo` but in  Ubuntu 17.10  it's called `lo0` and it was used as default. 

Now the system detects the real loopback interface name.

Thanks for @donwellus for reporting