### PR TITLE
removing shell command when discovering root's home dir

### DIFF
--- a/conf/macos-tunnel.sh.tpl
+++ b/conf/macos-tunnel.sh.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-HOME_ROOT=$(shell echo ~root)
+HOME_ROOT=$(echo ~root)
 
 ifconfig lo0 alias 172.17.0.1
 


### PR DESCRIPTION
`$(shell echo ~root)` gives `./macos-tunnel.sh: line 3: shell: command not found`.
Without the `shell` executable works just fine.