### PR TITLE
Adding generic empty Makefile to support unknown distributions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ else
 	NAME := $(shell echo ${NAME} | sed -e s/\"//g)
 	VERSION_MAJOR_ID=$(shell echo ${VERSION_ID} | cut -d. -f1)
 endif
-include conf/Makefile/${UNAME}_${NAME}${VERSION_MAJOR_ID}.mk
+ifeq ("$(wildcard ./conf/Makefile/${UNAME}_${NAME}${VERSION_MAJOR_ID}.mk)","")
+	include conf/Makefile/${UNAME}_Empty.mk
+else
+    include conf/Makefile/${UNAME}_${NAME}${VERSION_MAJOR_ID}.mk
+endif
 
 _check-docker-is-up:
 ifneq (${UNAME},Darwin)

--- a/conf/Makefile/Linux_Empty.mk
+++ b/conf/Makefile/Linux_Empty.mk
@@ -1,0 +1,16 @@
+OS_VERSION=None
+LOOPBACK := $(shell ifconfig | grep -i LOOPBACK  | head -n1 | cut -d\  -f1 | sed -e 's\#:\#\#')
+IP := $(shell ifconfig ${DOCKER_INTERFACE} | grep "inet " | cut -dt -f2 | cut -d: -f2 | sed -e 's\# \#\#' | cut -d\  -f1)
+DOCKER_CONF_FOLDER := /etc/docker
+DNSs := $(shell nmcli dev show | grep DNS|  cut -d\: -f2 | sort | uniq | sed s/\ //g | sed ':a;N;$!ba;s/\\\n/","/g');
+DNSs := $(shell echo "${DNSs}" | sed s/\ /\",\"/g | sed s/\;//g)
+DNSMASQ_LOCAL_CONF := /etc/NetworkManager/dnsmasq.d/01_docker
+PUBLISH_IP_MASK = $(IP):
+RESOLVCONF := /etc/resolv.conf
+PACKAGE_MANAGER=echo
+
+install-dependencies-os:
+
+install-os:
+
+uninstall-os:


### PR DESCRIPTION
In distributions that don't have a `Makefile` in `conf/Makefile`, `make` errors out on:

```
include conf/Makefile/${UNAME}_${NAME}${VERSION_MAJOR_ID}.mk
```

or freezes because it can't find the distro-specific targets (`install-os`, `install-dependencies-os`, etc).

This PR adds a empty definition that does nothing, but allows `make` to work and at least build docker images to be installed manually.