### PR TITLE
Fix docker deamon bip address

### DIFF
--- a/src/dockerapi.py
+++ b/src/dockerapi.py
@@ -5,15 +5,17 @@ errors = docker.errors
 
 client = docker.from_env()
 
-__network_config = client.networks.get(
-    'bridge').attrs['IPAM']['Config'][0]
-NETWORK_SUBNET = __network_config['Subnet']
-NETWORK_GATEWAY = None
-if 'Gateway' in __network_config:
-    NETWORK_GATEWAY = __network_config['Gateway']
-else:
+__network_config = client.networks.get('bridge').attrs.get('IPAM').get('Config')[0]
+
+NETWORK_SUBNET = __network_config.get('Subnet')
+DAEMON_BIP = NETWORK_SUBNET.split('.')
+ip_range = DAEMON_BIP[-1].split('/')[-1]
+DAEMON_BIP[-1] = f'1/{ip_range}'
+DAEMON_BIP = '.'.join(DAEMON_BIP)
+NETWORK_GATEWAY = __network_config.get('Gateway')
+if not NETWORK_GATEWAY:
     NETWORK_GATEWAY = NETWORK_SUBNET.split('.')
-    NETWORK_GATEWAY[3] = '1'
+    NETWORK_GATEWAY[-1] = '1'
     NETWORK_GATEWAY = '.'.join(NETWORK_GATEWAY)
 
 

--- a/src/install.py
+++ b/src/install.py
@@ -62,7 +62,7 @@ def main(name=config.DOCKER_CONTAINER_NAME, tag=config.DOCKER_CONTAINER_TAG, tld
         shutil.copy2('src/templates/daemon.json', DOCKER_CONF_FILE)
 
     docker_json = json.loads(open(DOCKER_CONF_FILE, 'r').read())
-    docker_json['bip'] = docker.NETWORK_SUBNET
+    docker_json['bip'] = docker.DAEMON_BIP
     docker_json['dns'] = list(
         set([docker.NETWORK_GATEWAY] + network.get_dns_servers()))
     with open(DOCKER_CONF_FILE, 'w') as daemon_file:

--- a/src/install.py
+++ b/src/install.py
@@ -55,17 +55,17 @@ def main(name=config.DOCKER_CONTAINER_NAME, tag=config.DOCKER_CONTAINER_TAG, tld
             open(RESOLVCONF, 'w').write(RESOLVCONF_DATA)
 
     # docker
-    DOCKER_CONF_FILE = f"{OS.DOCKER_CONF_FOLDER}/daemon.json"
-    if not os.path.exists(DOCKER_CONF_FILE) or os.stat(DOCKER_CONF_FILE).st_size == 0:
+    docker_conf_file = f"{OS.DOCKER_CONF_FOLDER}/daemon.json"
+    if not os.path.exists(docker_conf_file) or os.stat(docker_conf_file).st_size == 0:
         if not os.path.isdir(OS.DOCKER_CONF_FOLDER):
             os.mkdir(OS.DOCKER_CONF_FOLDER)
-        shutil.copy2('src/templates/daemon.json', DOCKER_CONF_FILE)
+        shutil.copy2('src/templates/daemon.json', docker_conf_file)
 
-    docker_json = json.loads(open(DOCKER_CONF_FILE, 'r').read())
+    docker_json = json.loads(open(docker_conf_file, 'r').read())
     docker_json['bip'] = docker.DAEMON_BIP
     docker_json['dns'] = list(
         set([docker.NETWORK_GATEWAY] + network.get_dns_servers()))
-    with open(DOCKER_CONF_FILE, 'w') as daemon_file:
+    with open(docker_conf_file, 'w') as daemon_file:
         daemon_file.write(json.dumps(docker_json, indent=4, sort_keys=True))
 
     if docker.check_exists(name):


### PR DESCRIPTION
Bip address from docker daemon.json file was distributing its address from "0" and it was causing conflicts on docker network.
When machine was restarted docker service was unable to star properly.

Wrong bip example: `"172.17.0.0/24"`, the last 0 is causing all the problem.

Fixed bip example: `"172.17.0.1/24"`, 0 replaced with 1 fixes the conflict problem.
