### PR TITLE
feat: Add regex get system version for Ubuntu 22.04

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -35,8 +35,8 @@ elif util.on_windows or util.on_wsl:
         f"{POWERSHELL_PATH} [Environment]::OSVersion.Version.Major").read().split('\n')[0]
     version = [VERSION_MAJOR_ID, 0]
 else:
-    VERSION_MAJOR_ID = open(
-        '/etc/os-release', 'r').read().split('VERSION_ID="')[1].split('"')[0]
+    VERSION_MAJOR_ID = re.search('VERSION_ID=\"(\d+\.\d+)\"', open('/etc/os-release',
+                'r').read()).group(1)
     version = VERSION_MAJOR_ID.split('.')
 
 if len(version) > 1:

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,7 @@ import socket
 import platform
 import util
 import json
+import re
 
 
 APP = os.path.basename(sys.argv[0])
@@ -21,8 +22,8 @@ if util.on_macos or util.on_windows:
     NAME = platform.uname()[0]
 
 else:
-    NAME = open('/etc/os-release',
-                'r').read().split('NAME="')[1].split('"')[0]
+    NAME = re.search('(NAME=\")(\w+)\"', open('/etc/os-release',
+                'r').read()).group(2)
 
 if util.on_macos:
     VERSION_MAJOR_ID = '.'.join(platform.mac_ver()[0].split('.')[0:2])

--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,7 @@ if util.on_macos or util.on_windows:
 
 else:
     NAME = re.search('NAME=\"(\w+)\"', open('/etc/os-release',
-                'r').read()).group(1)
+                                            'r').read()).group(1)
 
 if util.on_macos:
     VERSION_MAJOR_ID = '.'.join(platform.mac_ver()[0].split('.')[0:2])
@@ -36,7 +36,7 @@ elif util.on_windows or util.on_wsl:
     version = [VERSION_MAJOR_ID, 0]
 else:
     VERSION_MAJOR_ID = re.search('VERSION_ID=\"(\d+\.\d+)\"', open('/etc/os-release',
-                'r').read()).group(1)
+                                                                   'r').read()).group(1)
     version = VERSION_MAJOR_ID.split('.')
 
 if len(version) > 1:

--- a/src/config.py
+++ b/src/config.py
@@ -22,8 +22,8 @@ if util.on_macos or util.on_windows:
     NAME = platform.uname()[0]
 
 else:
-    NAME = re.search('(NAME=\")(\w+)\"', open('/etc/os-release',
-                'r').read()).group(2)
+    NAME = re.search('NAME=\"(\w+)\"', open('/etc/os-release',
+                'r').read()).group(1)
 
 if util.on_macos:
     VERSION_MAJOR_ID = '.'.join(platform.mac_ver()[0].split('.')[0:2])


### PR DESCRIPTION
## What this PR does?

Add support for Ubuntu 22.04.

### The problem

The `/etc/os-release` file changed It's struct on Ubuntu 22.04.

The logic use a split() base on any string `NAME=` to get the system version.
After this release the properties list order was changed, and broke the use of split()

Ubuntu 20.04 old file
```
NAME="Ubuntu"
VERSION="20.04.4 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.4 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

Ubuntu 22.04 new file
```
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

### The solution

The logic was changed from split() based on any string `NAME=` to a Regex based on the strict `NAME=`.



