### PR TITLE
Fix getting linux version

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -37,9 +37,13 @@ elif util.on_wsl:
     OS_VERSION = os.popen(f'{powershell_path} {version_path}').read().split(' ')[-1].replace('\n', '')
 
 else:
-    # OS_VERSION example: '20.04.1'
-    version_pattern = re.compile('~(.*)-')
-    OS_VERSION = re.search(pattern=version_pattern, string=platform.uname().version).group(1)
+    # OS_VERSION example: '20.04'
+    release_lines = open('/etc/os-release').readlines()
+    release_info = {
+        k.lower(): v.replace('"', '').replace('\n', '')
+        for k, v in [line.split('=') for line in release_lines]
+    }
+    OS_VERSION = release_info.get('version_id')
 
 OS = f'{HOSTUNAME}_{NAME}'
 TOP_LEVEL_DOMAIN = (util.read_cache('tld') or 'docker').strip()


### PR DESCRIPTION
# Fix Getting OS Version

The previous way works perfectly on kernel version `5.15.0-46-generic`
```
$ uname -a
> Linux HUNB707 5.15.0-46-generic #49~20.04.1-Ubuntu SMP Thu Aug 4 19:15:44 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```

But on version `5.14.0-1051-oem`
```
$ uname -a
> Linux HUNB1127 5.14.0-1051-oem #58-Ubuntu SMP Fri Aug 26 05:50:00 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```

The output is very similar but doesn't have the Ubuntu version that should be extracted with the regex.
Good: `#49~20.04.1-Ubuntu`

Bad: `#58-Ubuntu`

To solve this problem the solution is getting the information from de file `/etc/os-release`.

This solution is used in the *platform* lib but its only available for Python >= 3.10
https://docs.python.org/3.10/library/platform.html#platform.freedesktop_os_release

The default version of Python shipped in Ubuntu is 3.8, to don't obrigate the user to upgrade theire Python version the proposed solution is the best option.